### PR TITLE
fix: GitHub Pagesトップページにライセンス表示を追加

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,9 +44,13 @@ title: ホーム
 
 - Email: [ootakazuhiko@gmail.com](mailto:ootakazuhiko@gmail.com)
 
-## ライセンス
+---
 
-MIT
+## 📄 ライセンス
+
+本書はCreative Commons BY-NC-SA 4.0ライセンスで公開されています。
+
+🔓 教育・研究・個人学習での利用は自由ですが、💼 商用利用には事前許諾が必要です。[詳細なライセンス条件](https://github.com/ootakazuhiko/SuperMarket-book/blob/main/LICENSE.md)
 
 ---
 


### PR DESCRIPTION
## 変更内容
- GitHub Pagesのトップページ（docs/index.md）にCC BY-NC-SA 4.0ライセンス表示を追加
- 古いMITライセンス表記を削除

## 修正理由
- GitHub Pagesで公開されている書籍にライセンス表示がなかった
- 以前のMITライセンス表記が残っていた

## 表示内容
```
本書はCreative Commons BY-NC-SA 4.0ライセンスで公開されています。
🔓 教育・研究・個人学習での利用は自由ですが、💼 商用利用には事前許諾が必要です。詳細なライセンス条件
```

「詳細なライセンス条件」にGitHubリポジトリのLICENSE.mdへのリンクを設定