### PR TITLE
fix: 付録A/Bのタイトル表記を修正

### DIFF
--- a/docs/appendices/appendix-a.md
+++ b/docs/appendices/appendix-a.md
@@ -7,11 +7,11 @@ CC BY-NC-SA 4.0ライセンスの下で提供されます。
 
 ---
 layout: book
-title: "付録B　計算式一覧"
+title: "付録A　計算式一覧"
 chapter: appendix-a
 ---
 
-# 付録B　計算式一覧
+# 付録A　計算式一覧
 
 
 

--- a/docs/appendices/appendix-b.md
+++ b/docs/appendices/appendix-b.md
@@ -7,11 +7,11 @@ CC BY-NC-SA 4.0ライセンスの下で提供されます。
 
 ---
 layout: book
-title: "付録A　用語集"
+title: "付録B　用語集"
 chapter: appendix-b
 ---
 
-# 付録A　用語集
+# 付録B　用語集
 
 
 


### PR DESCRIPTION
## 修正内容
付録のタイトル表記がずれていた問題を修正しました。

### 変更詳細
- **appendix-a.md**: 付録B → 付録A (計算式一覧)
- **appendix-b.md**: 付録A → 付録B (用語集)
- **appendix-c.md**: 付録C (参考資料) は正しいため変更なし

## 確認結果
- docsディレクトリ内の付録ファイルのタイトルが正しく修正されました
- srcディレクトリ内の付録ファイルは元から正しい表記でした
- インデックスページのリンクテキストも正しいことを確認済み

## 修正前後の対応
| ファイル | 修正前 | 修正後 | 内容 |
|---------|--------|--------|------|
| appendix-a.md | 付録B | 付録A | 計算式一覧 |
| appendix-b.md | 付録A | 付録B | 用語集 |
| appendix-c.md | 付録C | 付録C | 参考資料 |